### PR TITLE
Debug matrice tf idf

### DIFF
--- a/TfIdf.py
+++ b/TfIdf.py
@@ -6,6 +6,7 @@ from IDF import CalculateIDF, create_file_words_dict, RegroupAllWords
 def TfIdf_Matrice(directory='./cleaned/'):
     list_files = list_of_files('./cleaned', '.txt')
     matrice = [[files.replace('_cleaned', '') for files in list_files]]
+    matrice[0].insert(0, '')
     idf = CalculateIDF()
     file_words = create_file_words_dict()
     allWords = RegroupAllWords(file_words)


### PR DESCRIPTION
Debug matrice tf-idf, ajout d'une case vide à la première ligne pour que les noms de fichiers soient alignés avec les scores.